### PR TITLE
Use `Char` as a parsing unit instead of `UInt8`

### DIFF
--- a/src/html.jl
+++ b/src/html.jl
@@ -16,15 +16,15 @@ end
 
 Base.showable(::MIME"text/html", printer::HTMLPrinter) = isreadable(printer.buf)
 
-const HTML_ESC_CHARS = Dict{UInt8, String}(
-    UInt8('\'') => "&apos;",
-    UInt8('\"') => "&quot;",
-    UInt8('<') => "&lt;",
-    UInt8('>') => "&gt;",
-    UInt8('&') => "&amp;",
+const HTML_ESC_CHARS = Dict{Char, String}(
+    '\'' => "&#39;",
+    '\"' => "&quot;",
+    '<' => "&lt;",
+    '>' => "&gt;",
+    '&' => "&amp;",
 )
 
-escape_char(::HTMLPrinter, c::UInt8) = get(HTML_ESC_CHARS, c, nothing)
+escape_char(::HTMLPrinter, c::Char) = get(HTML_ESC_CHARS, c, nothing)
 
 function Base.show(io::IO, ::MIME"text/html", printer::HTMLPrinter)
     if isempty(printer.root_class)

--- a/test/html.jl
+++ b/test/html.jl
@@ -19,6 +19,6 @@ end
 
     io = IOBuffer()
     show(io, MIME"text/html"(), hp)
-    @test "<pre>\n&quot;HTMLWriter&quot; uses &apos;&lt;pre&gt;&apos; &amp; " *
-          "&apos;&lt;span&gt;&apos; elements.</pre>" == String(take!(io))
+    @test "<pre>\n&quot;HTMLWriter&quot; uses &#39;&lt;pre&gt;&#39; &amp; " *
+          "&#39;&lt;span&gt;&#39; elements.</pre>" == String(take!(io))
 end


### PR DESCRIPTION
Although `Char` is not as fast as `UInt8`, it is better in terms of customizability.
This also fixes the "&apos;", which is not defined in HTML 4.