### PR TITLE
Add `root_tag` and `callback` kwargs to `HTMLPrinter()`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -42,7 +42,7 @@ actually outputs HTML code that looks like:
 ```@example ex
 htmlsrc = IOBuffer() # hide
 show(htmlsrc, MIME"text/html"(), printer) # hide
-print(String(take!(htmlsrc))[1:120], "...") # hide
+print(String(take!(htmlsrc))[1:119], "...") # hide
 ```
 
 In addition, the colors and text styles are controlled by the CSS in the host

--- a/docs/src/output-formats.md
+++ b/docs/src/output-formats.md
@@ -35,3 +35,28 @@ repr("text/plain", printer, context = :color => true) # optimized
 fragment (`MIME"text/html"`).
 
 See [Supported Codes](@ref) for examples.
+
+The [`HTMLPrinter`](@ref) constructor supports the `callback` keyword argument.
+The `callback` method will be called just before writing HTML tags. You can
+rewrite the attributes in your `callback` methods. You can also prevent the
+default tag writing by setting the return value of the `callback` method to
+something other than `nothing`.
+
+```@example ex
+src = IOBuffer();
+print(src, " Normal ", "\e[48;5;246m", " GrayBG ", "\e[0m", " Normal ");
+
+HTMLPrinter(src) # without callback method
+```
+
+```@repl ex
+function cb(io::IO, printer::HTMLPrinter, tag::String, attrs::Dict{Symbol, String})
+    text = String(take!(io))
+    @show text
+    @show tag, attrs
+    return true # prevent default writing
+end;
+
+dummy = IOBuffer();
+show(dummy, MIME"text/html"(), HTMLPrinter(src, callback = cb));
+```

--- a/src/html.jl
+++ b/src/html.jl
@@ -5,19 +5,45 @@ struct HTMLPrinter <: StackModelPrinter
     prevctx::SGRContext
     ctx::SGRContext
     root_class::String
-    function HTMLPrinter(buf::IO; root_class::AbstractString="")
-        new(buf, String[], SGRContext(), SGRContext(), String(root_class))
+    root_tag::String
+    callback::Any
+    function HTMLPrinter(buf::IO;
+                         root_class::AbstractString = "",
+                         root_tag::AbstractString = "pre",
+                         callback::Any = nothing)
+        new(buf, String[], SGRContext(), SGRContext(),
+            String(root_class), String(root_tag), callback)
     end
 end
 
 """
-    HTMLPrinter(buf::IO; root_class="")
+    HTMLPrinter(buf::IO; root_class="", root_tag="pre", callback=nothing)
 
 Creates a printer for `MIME"text/html"` output.
 
 # Arguments
 - `buf`: A source `IO` object containing a text with ANSI escape codes.
 - `root_class`: The `class` attribute value for the root element.
+- `root_tag`: The tag name for the root element.
+- `callback`: A callback method (see below).
+
+# Callback method
+
+    callback(io::IO, printer::HTMLPrinter, tag::String, attrs::Dict{Symbol, String})
+
+The `callback` method will be called just before writing HTML tags.
+
+## Callback arguments
+- `io`: The destination `IO` object.
+- `printer`: The `HTMLPrinter` in use.
+- `tag`: The HTML tag to be written. For closing tags, they have the prefix "/".
+- `attrs`: A dictionary consisting of pairs of a `Symbol` for the attributes
+  (e.g. `:class`, `:style`) and the `String` for its value.
+
+## Callback return value
+If the return value is `nothing`, the printer writes the HTML tag to the `io`
+according to the `tag` and the `attrs` after the call. If the return value is
+not `nothing`, this default writing will be prevented.
 """
 function HTMLPrinter end
 
@@ -34,25 +60,46 @@ const HTML_ESC_CHARS = Dict{Char, String}(
 escape_char(::HTMLPrinter, c::Char) = get(HTML_ESC_CHARS, c, nothing)
 
 function Base.show(io::IO, ::MIME"text/html", printer::HTMLPrinter)
-    if isempty(printer.root_class)
-        write(io, "<pre>\n")
-    else
-        write(io, "<pre class=\"", printer.root_class, "\">\n")
-    end
+    tag = printer.root_tag
+    attrs = Dict{Symbol, String}()
+    isempty(printer.root_class) || push!(attrs, :class => printer.root_class)
+
+    write_htmltag(io, printer, printer.root_tag, attrs)
+
     show_body(io, printer)
-    write(io, "</pre>")
+
+    write_htmltag(io, printer, "/" * printer.root_tag)
 end
 
 function start_new_state(io::IO, printer::HTMLPrinter)
     class = printer.stack[end]
     ctx = printer.ctx
+    attrs = Dict{Symbol, String}(:class => "sgr" * class)
+
     if occursin(r"^38_[25]$", class)
-        write(io, "<span class=\"sgr", class, "\" style=\"color:#", ctx.fg.hex, "\">")
+        push!(attrs, :style => "color:#" * ctx.fg.hex)
     elseif occursin(r"^48_[25]$", class)
-        write(io, "<span class=\"sgr", class, "\" style=\"background:#", ctx.bg.hex, "\">")
-    else
-        write(io, "<span class=\"sgr", class, "\">")
+        push!(attrs, :style => "background:#" * ctx.bg.hex)
     end
+
+    write_htmltag(io, printer, "span", attrs)
 end
 
-end_current_state(io::IO, printer::HTMLPrinter) = write(io, "</span>")
+function end_current_state(io::IO, printer::HTMLPrinter)
+    write_htmltag(io, printer, "/span", )
+end
+
+function write_htmltag(io::IO, printer::HTMLPrinter,
+                       tag::String, attrs::Dict{Symbol, String} = Dict{Symbol, String}())
+    if printer.callback !== nothing
+        result = printer.callback(io, printer, tag, attrs)
+        result === nothing || return
+    end
+    write(io, "<", tag)
+    for k in sort!(collect(keys(attrs)))
+        v = attrs[k]
+        isempty(v) && continue
+        write(io, " ", k, "=\"", v, "\"")
+    end
+    write(io, ">")
+end

--- a/test/html.jl
+++ b/test/html.jl
@@ -11,7 +11,7 @@ end
     printer = HTMLPrinter(buf)
 
     print(buf, "This is a plain text.")
-    @test repr_html(printer) == "<pre>\nThis is a plain text.</pre>"
+    @test repr_html(printer) == "<pre>This is a plain text.</pre>"
 end
 
 @testset "escape" begin
@@ -20,7 +20,7 @@ end
 
     print(buf, "\"HTMLWriter\" uses '<pre>' & '<span>' elements.")
     result = repr_html(printer)
-    @test result == "<pre>\n&quot;HTMLWriter&quot; uses &#39;&lt;pre&gt;&#39; &amp; " *
+    @test result == "<pre>&quot;HTMLWriter&quot; uses &#39;&lt;pre&gt;&#39; &amp; " *
                     "&#39;&lt;span&gt;&#39; elements.</pre>"
 end
 
@@ -34,7 +34,7 @@ end
         print(buf, "\e[2m", " Faint ")
         print(buf, "\e[22m", " Normal ")
         result = repr_html(printer)
-        @test result == "<pre>\n" * """ Normal <span class="sgr1"> Bold </span>""" *
+        @test result == """<pre> Normal <span class="sgr1"> Bold </span>""" *
                         """<span class="sgr2"> Faint </span> Normal </pre>"""
     end
 
@@ -44,7 +44,7 @@ end
         print(buf, "\e[39;44m", " BlueBG ")
         print(buf, "\e[49m", " Normal ")
         result = repr_html(printer)
-        @test result == "<pre>\n" * """ Normal <span class="sgr36"> CyanFG </span>""" *
+        @test result == """<pre> Normal <span class="sgr36"> CyanFG </span>""" *
                         """<span class="sgr44"> BlueBG </span> Normal </pre>"""
     end
 
@@ -54,7 +54,7 @@ end
         print(buf, "\e[6m", " RapidBlink ")
         print(buf, "\e[25m", " Normal ")
         result = repr_html(printer)
-        @test result == "<pre>\n" * """ Normal <span class="sgr5"> Blink </span>""" *
+        @test result == """<pre> Normal <span class="sgr5"> Blink </span>""" *
                         """<span class="sgr6"> RapidBlink </span> Normal </pre>"""
     end
 end
@@ -70,7 +70,7 @@ end
         print(buf, "\e[23m", " Bold ")
         print(buf, "\e[0m", " Normal ")
         result = repr_html(printer)
-        @test result == "<pre>\n" * """ Normal <span class="sgr1"> Bold """ *
+        @test result == """<pre> Normal <span class="sgr1"> Bold """ *
                         """<span class="sgr3"> Bold-Italic </span>""" *
                         """ Bold </span> Normal </pre>"""
 
@@ -79,7 +79,7 @@ end
         print(buf, "\e[22m", " Italic ")
         print(buf, "\e[0m", " Normal ")
         result = repr_html(printer)
-        @test result == """<pre>\n<span class="sgr3"> Italic """ *
+        @test result == """<pre><span class="sgr3"> Italic """ *
                         """<span class="sgr1"> Bold-Italic </span>""" *
                         """ Italic </span> Normal </pre>"""
     end
@@ -91,7 +91,7 @@ end
         print(buf, "\e[39m", " Bold ")
         print(buf, "\e[0m", " Normal ")
         result = repr_html(printer)
-        @test result == "<pre>\n" * """ Normal <span class="sgr1"> Bold """ *
+        @test result == """<pre> Normal <span class="sgr1"> Bold """ *
                         """<span class="sgr36"> Bold-CyanFG </span>""" *
                         """ Bold </span> Normal </pre>"""
     end
@@ -103,7 +103,7 @@ end
         print(buf, "\e[25m", " Strike ")
         print(buf, "\e[29m", " Normal ")
         result = repr_html(printer)
-        @test result == "<pre>\n" * """ Normal <span class="sgr9"> Strike """ *
+        @test result == """<pre> Normal <span class="sgr9"> Strike """ *
                         """<span class="sgr5"> Strike-Blink </span>""" *
                         """ Strike </span> Normal </pre>"""
     end
@@ -115,7 +115,7 @@ end
         print(buf, "\e[49m", " LightCyanFG ")
         print(buf, "\e[39m", " Normal ")
         result = repr_html(printer)
-        @test result == "<pre>\n" * """ Normal <span class="sgr96"> LightCyanFG """ *
+        @test result == """<pre> Normal <span class="sgr96"> LightCyanFG """ *
                         """<span class="sgr45"> LightCyanFG-MagentaBG </span>""" *
                         """ LightCyanFG </span> Normal </pre>"""
     end
@@ -132,7 +132,7 @@ end
         print(buf, "\e[22;36m", " CyanFG ")
         print(buf, "\e[39m", " Normal ")
         result = repr_html(printer)
-        @test result == "<pre>\n" * """ Normal <span class="sgr1"> Bold """ *
+        @test result == """<pre> Normal <span class="sgr1"> Bold """ *
                         """<span class="sgr36"> Bold-CyanFG </span></span>""" *
                         """<span class="sgr36"> CyanFG </span> Normal </pre>"""
     end
@@ -144,7 +144,7 @@ end
         print(buf, "\e[39m", " MagentaBG ")
         print(buf, "\e[49m", " Normal ")
         result = repr_html(printer)
-        @test result == "<pre>\n" * """ Normal <span class="sgr96"> LightCyanFG """ *
+        @test result == """<pre> Normal <span class="sgr96"> LightCyanFG """ *
                         """<span class="sgr45"> LightCyanFG-MagentaBG </span></span>""" *
                         """<span class="sgr45"> MagentaBG </span> Normal </pre>"""
     end
@@ -157,7 +157,7 @@ end
     print(buf, "\e[7m", " Invert ")
     print(buf, "\e[8m", " Conceal ")
     result = repr_html(printer)
-    @test result == """<pre>\n<span class="sgr7"> Invert <span class="sgr8"> Conceal """ *
+    @test result == """<pre><span class="sgr7"> Invert <span class="sgr8"> Conceal """ *
                     """</span></span></pre>"""
 end
 
@@ -171,7 +171,7 @@ end
     print(buf, "\e[48;5;255m", " #eee(BG) ")
 
     result = repr_html(printer)
-    @test result == """<pre>\n<span class="sgr34"> Blue(FG) """ *
+    @test result == """<pre><span class="sgr34"> Blue(FG) """ *
                     """<span class="sgr48_5" style="background:#000"> #000(BG) """ *
                     """</span></span><span class="sgr48_5" style="background:#000">""" *
                     """<span class="sgr38_5" style="color:#87afd7"> #87afd7(FG) """ *
@@ -189,9 +189,72 @@ end
     print(buf, "\e[38;2;170;187;204m", " #abc(FG) ")
 
     result = repr_html(printer)
-    @test result == """<pre>\n<span class="sgr38_2" style="color:#0080ff"> #0080ff(FG) """ *
+    @test result == """<pre><span class="sgr38_2" style="color:#0080ff"> #0080ff(FG) """ *
                     """<span class="sgr48_5" style="background:#eee"> #eee(BG) """ *
                     """</span></span><span class="sgr48_5" style="background:#eee">""" *
                     """<span class="sgr38_2" style="color:#abc"> #abc(FG) """ *
                     """</span></span></pre>"""
+end
+
+@testset "callback" begin
+    @testset "use default" begin
+        counter = 0
+        function cb(io, printer, tag, attrs)
+            startswith(tag, "/") && return nothing
+            push!(attrs, :id => tag * string(counter))
+            counter += 1
+            return nothing
+        end
+
+        buf = IOBuffer()
+        printer = HTMLPrinter(buf, root_class = "root test", root_tag = "code", callback = cb)
+
+        print(buf, "\e[0m", " Normal ")
+        print(buf, "\e[38;5;255m", " #eee(FG) ")
+        print(buf, "\e[0m", " Normal ")
+
+        result = repr_html(printer)
+        @test result == """<code class="root test" id="code0"> Normal """ *
+                        """<span class="sgr38_5" id="span1" style="color:#eee">""" *
+                        """ #eee(FG) </span> Normal </code>"""
+    end
+
+    @testset "prevent default" begin
+        dom = Tuple[(:rootnode, Tuple[])]
+        function cb(io, printer, tag, attrs)
+            text = String(take!(io))
+            parent = dom[end]
+            children = parent[end]
+            isempty(text) || push!(children, (:textnode, text))
+
+            if startswith(tag, "/")
+                pop!(dom)
+            else
+                parent = (Symbol(tag), attrs, Tuple[])
+                push!(children, parent)
+                push!(dom, parent)
+            end
+            return true
+        end
+
+        buf = IOBuffer()
+        printer = HTMLPrinter(buf, callback = cb)
+
+        print(buf, "\e[0m", " Normal ")
+        print(buf, "\e[38;5;255m", " #eee(FG) ")
+        print(buf, "\e[0m", " Normal ")
+
+        result = repr_html(printer)
+        @test result == ""
+        @test dom[1] ==
+                (:rootnode, Tuple[
+                    (:pre, Dict{Symbol,String}(), Tuple[
+                        (:textnode, " Normal "),
+                        (:span, Dict(:class => "sgr38_5", :style => "color:#eee"), Tuple[
+                            (:textnode, " #eee(FG) ")
+                        ]),
+                        (:textnode, " Normal ")
+                    ])
+                ])
+    end
 end


### PR DESCRIPTION
This also removes the "\n" after `"<pre>"` tag for consistency.