### PR TITLE
Improve support for environments where "invert" is problematic

### DIFF
--- a/docs/src/assets/default.css
+++ b/docs/src/assets/default.css
@@ -28,8 +28,28 @@ html span.sgr7 {
     background-color: #222;
 }
 
+html span.sgr-39 {
+    /* default inverted foreground color */
+    color: #fff;
+}
+
+html span.sgr-49 {
+    /* default inverted background color */
+    background-color: #222;
+}
+
 html.theme--documenter-dark span.sgr7 {
     color: #1f2424;
+    background-color: #fff;
+}
+
+html.theme--documenter-dark span.sgr-39 {
+    /* default inverted foreground color */
+    color: #1f2424;
+}
+
+html.theme--documenter-dark span.sgr-49 {
+    /* default inverted background color */
     background-color: #fff;
 }
 

--- a/docs/src/supported-codes.md
+++ b/docs/src/supported-codes.md
@@ -39,19 +39,21 @@ print(buf, "\e[4;9m", " Both ", "\e[m")
 HTMLPrinter(buf, root_class="documenter-example-output")
 ```
 ## Invert
-The invert code swaps the foreground and background colors. However, the support
-is limited. You will need to force the foreground and background colors to be
-switched manually, or convert the style afterwards using JavaScript etc.
+The invert code swaps the foreground and background colors. The default setting
+of `HTMLPrinter` (`keep_invert=false`) reinterprets background color changes as
+foreground color changes, and vice versa, when "invert" is enabled. In this
+case, the normal inverted foreground color is marked up as `class="sgr-39"` and
+the normal inverted background color is marked up as `class="sgr-49"`.
 
 ```@example ex
 buf = IOBuffer()
 print(buf, "\e[0m", "Normal ")
 print(buf, "\e[7m", "Invert ")
 print(buf, "\e[27m", "Normal ")
-print(buf, "\e[7;100m", "GrayText? ") # not supported by default.css
-print(buf, "\e[34m", "BlueBG? ") # not supported by default.css
+print(buf, "\e[7;103m", "YellowText ")
+print(buf, "\e[34m", "BlueBG ")
 print(buf, "\e[0m", "Normal ")
-HTMLPrinter(buf, root_class="documenter-example-output")
+HTMLPrinter(buf, keep_invert=false, root_class="documenter-example-output")
 ```
 
 ## Conceal

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -3,18 +3,25 @@ struct PlainTextPrinter <: FlatModelPrinter
     buf::IO
     prevctx::SGRContext
     ctx::SGRContext
-    function PlainTextPrinter(buf::IO)
-        new(buf, SGRContext(), SGRContext())
+    keep_invert::Bool
+    function PlainTextPrinter(buf::IO; keep_invert::Bool=true)
+        new(buf, SGRContext(), SGRContext(), keep_invert)
     end
 end
 
 """
-    PlainTextPrinter(buf::IO)
+    PlainTextPrinter(buf::IO; keep_invert=true)
 
 Creates a printer for `MIME"text/plain"` output.
 
 # Arguments
 - `buf`: A source `IO` object containing a text with ANSI escape codes.
+- `keep_invert`: If true, "invert" (SGR code 7) is printed as is.
+
+If `keep_invert` is `false`, the color change codes with "invert" enable are
+reinterpreted as explicit foreground and background color specifications.
+In this case, the normal inverted foreground color is considered black (SGR code
+ 30) and the normal inverted background color is considered white (SGR code 47).
 """
 function PlainTextPrinter end
 
@@ -29,6 +36,11 @@ function change_state(io::IO, printer::PlainTextPrinter, ansicodes::Vector{Int})
     if isempty(ansicodes)
         print(io, "\e[m")
     else
+        if !printer.keep_invert
+            # normal inverted foreground color => 30 (black)
+            # normal inverted background color => 47 (white)
+            replace!(ansicodes, -39 => 30, -49 => 47)
+        end
         print(io, "\e[", join(ansicodes, ';'), 'm')
     end
 end

--- a/test/html.jl
+++ b/test/html.jl
@@ -150,6 +150,39 @@ end
     end
 end
 
+@testset "invert" begin
+    buf = IOBuffer()
+
+    @testset "keep_invert=$keep" for keep in (true, false)
+        print(buf, "\e[0m", " Normal ")
+        print(buf, "\e[7m", " Invert ")
+        print(buf, "\e[45m", " MagentaFG-InvBG ")
+        print(buf, "\e[96m", " MagentaFG-LightCyanBG ")
+        print(buf, "\e[49m", " InvFG-LightCyanBG ")
+        print(buf, "\e[27m", " LightCyanFG ")
+        print(buf, "\e[39m", " Normal ")
+        printer = HTMLPrinter(buf, keep_invert=keep)
+        result = repr_html(printer)
+        if keep
+            @test result == """<pre> Normal """ *
+                            """<span class="sgr7"> Invert """ *
+                            """<span class="sgr45"> MagentaFG-InvBG """ *
+                            """<span class="sgr96"> MagentaFG-LightCyanBG </span>""" *
+                            """</span><span class="sgr96"> InvFG-LightCyanBG </span>""" *
+                            """</span><span class="sgr96"> LightCyanFG </span> Normal </pre>"""
+        else
+            @test result == """<pre> Normal """ *
+                            """<span class="sgr-49"><span class="sgr-39"> Invert """ *
+                            """</span><span class="sgr35"> MagentaFG-InvBG </span>""" *
+                            """</span><span class="sgr35">""" *
+                            """<span class="sgr106"> MagentaFG-LightCyanBG </span>""" *
+                            """</span><span class="sgr106">""" *
+                            """<span class="sgr-39"> InvFG-LightCyanBG </span></span>""" *
+                            """<span class="sgr96"> LightCyanFG </span> Normal </pre>"""
+        end
+    end
+end
+
 @testset "force reset" begin
     buf = IOBuffer()
     printer = HTMLPrinter(buf)
@@ -157,8 +190,8 @@ end
     print(buf, "\e[7m", " Invert ")
     print(buf, "\e[8m", " Conceal ")
     result = repr_html(printer)
-    @test result == """<pre><span class="sgr7"> Invert <span class="sgr8"> Conceal """ *
-                    """</span></span></pre>"""
+    @test result == """<pre><span class="sgr-49"><span class="sgr-39"> Invert """ *
+                    """<span class="sgr8"> Conceal </span></span></span></pre>"""
 end
 
 @testset "256 colors" begin

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -125,6 +125,33 @@ end
     end
 end
 
+@testset "invert" begin
+    buf = IOBuffer()
+
+    @testset "keep_invert=$keep" for keep in (true, false)
+        print(buf, "\e[0m", " Normal ")
+        print(buf, "\e[7m", " Invert ")
+        print(buf, "\e[45m", " MagentaFG-InvBG ")
+        print(buf, "\e[96m", " MagentaFG-LightCyanBG ")
+        print(buf, "\e[49m", " InvFG-LightCyanBG ")
+        print(buf, "\e[27m", " LightCyanFG ")
+        print(buf, "\e[39m", " Normal ")
+        printer = PlainTextPrinter(buf, keep_invert=keep)
+        result = repr_color(printer)
+        if keep
+            @test result == " Normal \e[7m Invert \e[45m MagentaFG-InvBG " *
+                            "\e[96m MagentaFG-LightCyanBG " *
+                            "\e[49m InvFG-LightCyanBG " *
+                            "\e[27m LightCyanFG \e[m Normal "
+        else
+            @test result == " Normal \e[30;47m Invert \e[35m MagentaFG-InvBG " *
+                            "\e[106m MagentaFG-LightCyanBG " *
+                            "\e[30m InvFG-LightCyanBG " *
+                            "\e[96;49m LightCyanFG \e[m Normal "
+        end
+    end
+end
+
 @testset "force reset" begin
     buf = IOBuffer()
     printer = PlainTextPrinter(buf)


### PR DESCRIPTION
This adds the `keep_invert` option to `PlainTextPrinter` and `HTMLPrinter`.
This may fix https://github.com/JuliaDocs/Documenter.jl/issues/2487 with a few CSS modifications.

This is a somewhat breaking change, but I don't think "invert" is  used that much.

